### PR TITLE
Fix for "entrypoint.sh" used in Docker configuration.

### DIFF
--- a/packaging/docker/bin/entrypoint.sh
+++ b/packaging/docker/bin/entrypoint.sh
@@ -7,9 +7,9 @@ HASSIO_OPTIONSFILE=/data/options.json
 if [ -f ${HASSIO_OPTIONSFILE} ]; then
     CONFIG=$(grep -o '"config_file": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$')
     echo "Using config file: ${CONFIG}"
-    
+
     SQLITE_FILE=$(grep -o '"sqlite_file": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$')
-    
+
     if [ ! -f "${CONFIG}" ]; then
         echo "Config not found. Please create a config under ${CONFIG}."
         echo "For details see evcc documentation at https://github.com/evcc-io/evcc#readme."
@@ -23,7 +23,10 @@ if [ -f ${HASSIO_OPTIONSFILE} ]; then
         fi
     fi
 else
-    if [ "$1" = '"evcc"' ] || expr "$1" : '-*' > /dev/null; then
+    if [ "$1" = 'evcc' ]; then
+        shift
+        exec evcc "$@"
+    elif expr "$1" : '-.*' > /dev/null; then
         exec evcc "$@"
     else
         exec "$@"


### PR DESCRIPTION
Fix issue when calling this script with "entproint.sh evcc -option" which need to remove the first argument "evcc" before handing over to evcc. Otherwise this will result in execing "evcc evcc ..." which will not work.